### PR TITLE
[567448] Session listener on Textual Editor fix 

### DIFF
--- a/plugins/org.polarsys.capella.scenario.editor.embeddededitor/plugin.xml
+++ b/plugins/org.polarsys.capella.scenario.editor.embeddededitor/plugin.xml
@@ -28,12 +28,14 @@
       </perspectiveExtension>
    </extension>
    -->
+   <!--
    <extension
          point="org.eclipse.sirius.sessionManagerListener">
       <listener
             class="org.polarsys.capella.scenario.editor.embeddededitor.listener.EmbeddedEditorSessionListener">
       </listener>
    </extension>
+   -->
    
    	<extension
          point="org.eclipse.ui.bindings">

--- a/plugins/org.polarsys.capella.scenario.editor.embeddededitor/src/org/polarsys/capella/scenario/editor/embeddededitor/commands/DiagramToXtextCommands.java
+++ b/plugins/org.polarsys.capella.scenario.editor.embeddededitor/src/org/polarsys/capella/scenario/editor/embeddededitor/commands/DiagramToXtextCommands.java
@@ -89,8 +89,6 @@ public class DiagramToXtextCommands {
         TextualScenarioFactory factory = new TextualScenarioFactoryImpl();
         Model domainModel = HelperCommands.getModel(embeddedEditorViewPart);
         if (domainModel != null) {
-          HelperCommands.clearModel(domainModel);
-
           // Generate Participants
           generateParticipants(domainModel, scenario, factory);
 

--- a/plugins/org.polarsys.capella.scenario.editor.embeddededitor/src/org/polarsys/capella/scenario/editor/embeddededitor/commands/HelperCommands.java
+++ b/plugins/org.polarsys.capella.scenario.editor.embeddededitor/src/org/polarsys/capella/scenario/editor/embeddededitor/commands/HelperCommands.java
@@ -63,7 +63,7 @@ public class HelperCommands {
   }
   
   /**
-   * get the xtext model
+   * get the xtext model object (clear the model if content already exist in it)
    * 
    * @param embeddedEditorViewPart
    *          - this is the embedded editor xtext object
@@ -72,11 +72,8 @@ public class HelperCommands {
   public static Model getModel(EmbeddedEditorView embeddedEditorViewPart) {
     TextualScenarioProvider p = embeddedEditorViewPart.getProvider();
     XtextResource resource = p.getResource();
-    EList<EObject> content = resource.getContents();
     Model domainModel = null;
-    if (!content.isEmpty() && content.get(0) instanceof Model) {
-      domainModel = (Model) resource.getContents().get(0);
-    } else {
+    if (resource != null) {
       EmbeddedEditorInstanceHelper.updateModel("scenario {}");
       EList<EObject> content1 = resource.getContents();
       if (!content1.isEmpty() && content1.get(0) instanceof Model) {
@@ -120,6 +117,9 @@ public class HelperCommands {
         DiagramToXtextCommands.process(scenario, eeView); // update the embedded editor text view
         eeView.refreshTitleBar(scenario.getName()); 
       }
+    } else {
+    	eeView.refreshTitleBar("Textual Editor"); 
+    	EmbeddedEditorInstanceHelper.cleanUpModel();
     }
   }
 }

--- a/plugins/org.polarsys.capella.scenario.editor.embeddededitor/src/org/polarsys/capella/scenario/editor/embeddededitor/listener/EmbeddedEditorSessionListener.java
+++ b/plugins/org.polarsys.capella.scenario.editor.embeddededitor/src/org/polarsys/capella/scenario/editor/embeddededitor/listener/EmbeddedEditorSessionListener.java
@@ -12,22 +12,16 @@
  *******************************************************************************/
 package org.polarsys.capella.scenario.editor.embeddededitor.listener;
 
-import org.eclipse.jface.viewers.ISelection;
-import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.sirius.business.api.session.Session;
+import org.eclipse.sirius.business.api.session.SessionManager;
 import org.eclipse.sirius.business.api.session.SessionManagerListener;
 import org.eclipse.sirius.diagram.DDiagram;
 import org.eclipse.sirius.diagram.sequence.SequenceDDiagram;
-import org.eclipse.sirius.diagram.sequence.description.SequenceDiagramDescription;
 import org.eclipse.sirius.diagram.ui.tools.api.editor.DDiagramEditor;
-import org.eclipse.sirius.viewpoint.DRepresentationDescriptor;
 import org.eclipse.sirius.viewpoint.description.Viewpoint;
 import org.eclipse.ui.ISelectionListener;
-import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchPart;
-import org.eclipse.ui.PlatformUI;
 import org.polarsys.capella.core.data.interaction.Scenario;
-import org.polarsys.capella.core.model.handler.helpers.CapellaAdapterHelper;
 import org.polarsys.capella.scenario.editor.EmbeddedEditorInstance;
 import org.polarsys.capella.scenario.editor.embeddededitor.commands.HelperCommands;
 import org.polarsys.capella.scenario.editor.embeddededitor.helper.XtextEditorHelper;
@@ -38,15 +32,9 @@ import org.polarsys.capella.scenario.editor.embeddededitor.views.EmbeddedEditorV
  */
 public class EmbeddedEditorSessionListener implements SessionManagerListener {
   private static ISelectionListener selectionListener;
-  static Object currentSelected;
 
   @Override
   public void notify(Session session, int notification) {
-    if (PlatformUI.getWorkbench() != null && PlatformUI.getWorkbench().getActiveWorkbenchWindow() != null) {
-      IWorkbenchPage activePage = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
-      if (activePage != null)
-        activePage.addSelectionListener(getSelectionListener());
-    }
   }
 
   public static ISelectionListener getSelectionListener() {
@@ -55,15 +43,17 @@ public class EmbeddedEditorSessionListener implements SessionManagerListener {
     }
     return selectionListener;
   }
-  
+
   protected static ISelectionListener createSelectionListener() {
     return (part, selection) -> {
+
       if (part instanceof IWorkbenchPart) {
         DDiagram diagram = null;
+        // first case is when we navigate between the opened diagrams
         if (part instanceof DDiagramEditor) {
           // set the diagram
           DDiagramEditor dEditor = (DDiagramEditor) part;
-          if(dEditor.getRepresentation() instanceof DDiagram) {
+          if (dEditor.getRepresentation() instanceof DDiagram) {
             diagram = (DDiagram) dEditor.getRepresentation();
           }
         }
@@ -76,25 +66,37 @@ public class EmbeddedEditorSessionListener implements SessionManagerListener {
           DDiagram currentDiagram = EmbeddedEditorInstance.getDDiagram();
           if (currentDiagram == null || !currentDiagram.equals(diagram)) {
             // update the current selected diagram
-            EmbeddedEditorInstance.setDDiagram(diagram);
-            
-            EmbeddedEditorView eeView = XtextEditorHelper.getActiveEmbeddedEditorView();
-            if (eeView != null) {
-              // refresh the text editor if the textual embedded editor is opened
-              HelperCommands.refreshTextEditor(eeView);
-            }
+            updateLinkedTextualEditor(diagram);
           }
         }
       }
     };
   }
-  
+
+  private static void updateLinkedTextualEditor(DDiagram diagram) {
+    // update the diagram
+    EmbeddedEditorInstance.setDDiagram(diagram);
+
+    EmbeddedEditorView eeView = XtextEditorHelper.getActiveEmbeddedEditorView();
+    if (eeView != null) {
+      // refresh the text editor if the textual embedded editor is opened
+      HelperCommands.refreshTextEditor(eeView);
+    }
+  }
+
   @Override
   public void notifyAddSession(Session newSession) {
   }
 
   @Override
   public void notifyRemoveSession(Session removedSession) {
+    DDiagram currentDiagram = EmbeddedEditorInstance.getDDiagram();
+    if (currentDiagram != null) {
+      Session sessionForDiagram = SessionManager.INSTANCE.getSession(currentDiagram);
+      if (sessionForDiagram == null || removedSession.equals(sessionForDiagram)) {
+        updateLinkedTextualEditor(null);
+      }
+    }
   }
 
   @Override

--- a/plugins/org.polarsys.capella.scenario.editor/src/org/polarsys/capella/scenario/editor/helper/EmbeddedEditorInstanceHelper.java
+++ b/plugins/org.polarsys.capella.scenario.editor/src/org/polarsys/capella/scenario/editor/helper/EmbeddedEditorInstanceHelper.java
@@ -556,6 +556,10 @@ public class EmbeddedEditorInstanceHelper {
     });
   }
 
+  public static void cleanUpModel() {
+    updateModel("");
+  }
+  
   public static String getModelContent() {
     XtextDocument document = EmbeddedEditorInstance.getEmbeddedEditor().getDocument();
     return document.get();


### PR DESCRIPTION
* [567448] Session listener on Textual Editor fix


Change-Id: Icc7c42bb604bfef2b8fdae975c6ae6b4e0529f1a


* [567448] Session listener on Textual Editor fix

- on close session, flush the Textual editor


Change-Id: I644f62404ec9b878c006b3648b024bfebcdc4ae8
Signed-off-by: Georgiana-Elena ECOBICI
<georgiana-elena.ecobici@thalesgroup.com>

* [567448] Session listener on Textual Editor fix

- fix spacing issues, return a clear model before reprocessing it


Change-Id: I2eb7c6986f94afcfff1b473ddf7e4d072190e304
Signed-off-by: Georgiana-Elena ECOBICI
<georgiana-elena.ecobici@thalesgroup.com>

Co-authored-by: Georgiana-Elena ECOBICI
<georgiana-elena.ecobici@thalesgroup.com>

Conflicts:
	plugins/org.polarsys.capella.scenario.editor.embeddededitor/plugin.xml
	plugins/org.polarsys.capella.scenario.editor.embeddededitor/src/org/polarsys/capella/scenario/editor/embeddededitor/listener/EmbeddedEditorSessionListener.java

Change-Id: I225cc379f8e918e4d23c09f66181039b28699dc0